### PR TITLE
Support optional keys in Kubernetes identification

### DIFF
--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -8,7 +8,7 @@ pub fn by_index() -> Box<dyn Fn(usize, &serde_yaml::Value) -> Option<DocKey>> {
     Box::new(|idx, _| {
         Some(DocKey::from(BTreeMap::from([(
             "idx".to_string(),
-            idx.to_string(),
+            Some(idx.to_string()),
         )])))
     })
 }
@@ -17,15 +17,16 @@ pub mod kubernetes {
     use super::*;
     use std::collections::BTreeMap;
 
-    fn string_of(node: &serde_yaml::Value) -> String {
-        node.as_str().map(String::from).unwrap()
+    fn string_of(node: Option<&serde_yaml::Value>) -> Option<String> {
+        node?.as_str().map(String::from)
     }
 
-    pub fn apiversion_resource_name() -> Box<dyn Fn(usize, &serde_yaml::Value) -> Option<DocKey>> {
+    /// Keys to identify immutable kinds
+    pub fn gvk() -> Box<dyn Fn(usize, &serde_yaml::Value) -> Option<DocKey>> {
         Box::new(|_, doc| {
-            let api_version = string_of(doc.get("apiVersion")?);
-            let kind = string_of(doc.get("kind")?);
-            let name = string_of(doc.get("metadata")?.get("name")?);
+            let api_version = string_of(doc.get("apiVersion"));
+            let kind = string_of(doc.get("kind"));
+            let name = string_of(doc.get("metadata")?.get("name"));
 
             Some(DocKey::from(BTreeMap::from([
                 ("api_version".to_string(), api_version),
@@ -35,17 +36,15 @@ pub mod kubernetes {
         })
     }
 
-    pub fn metadata_name() -> Box<dyn Fn(usize, &serde_yaml::Value) -> Option<DocKey>> {
+    /// Keys used to find renamed kinds
+    pub fn names() -> Box<dyn Fn(usize, &serde_yaml::Value) -> Option<DocKey>> {
         Box::new(|_, doc| {
-            doc.get("metadata")
-                .and_then(|m| m.get("name"))
-                .and_then(|n| n.as_str())
-                .map(|name| {
-                    DocKey::from(BTreeMap::from([(
-                        "metadata.name".to_string(),
-                        name.to_string(),
-                    )]))
-                })
+            let name = string_of(doc.get("metadata")?.get("name"));
+            let namespace = string_of(doc.get("metadata")?.get("namespace"));
+            Some(DocKey::from(BTreeMap::from([
+                ("metadata.name".to_string(), name),
+                ("metadata.namespace".to_string(), namespace),
+            ])))
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,10 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, ValueEnum};
 use diff::Difference;
 use multidoc::{AdditionalDoc, DocDifference, MissingDoc};
 
 mod diff;
 mod identifier;
 mod multidoc;
-
-#[derive(Subcommand, Debug)]
-enum Commands {}
 
 #[derive(Default, ValueEnum, Clone, Debug)]
 enum Comparison {
@@ -42,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 
     let id = match comparator {
         Comparison::Index => identifier::by_index(),
-        Comparison::Kubernetes => identifier::kubernetes::apiversion_resource_name(),
+        Comparison::Kubernetes => identifier::kubernetes::gvk(),
     };
 
     let ctx = multidoc::Context::new_with_doc_identifier(id);


### PR DESCRIPTION
we need to track both ns and name, and they can't both exist. Moving to options everywhere (since that is also closer to the real world).

Error handling for missing typemeta can be done separately.